### PR TITLE
add compatibility with older versions of the docker daemon (pre 1.9.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM golang:1.5.1
 
-ADD ./cuberite_server /srv/cuberite_server
-ADD ./world /srv/world
-ADD ./docs/img/logo64x64.png /srv/logo.png
-ADD ./start.sh /srv/start.sh
-ADD ./go /go
-ADD ./docker_linux_x64/docker /bin/docker
+COPY ./cuberite_server /srv/cuberite_server
+COPY ./world /srv/world
+COPY ./docs/img/logo64x64.png /srv/logo.png
+COPY ./start.sh /srv/start.sh
+COPY ./go /go
+COPY ./docker_linux_x64 /bin
 
 RUN chmod +x /bin/docker-*
 RUN cd /go/src/goproxy; go install

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ADD ./start.sh /srv/start.sh
 ADD ./go /go
 ADD ./docker_linux_x64/docker /bin/docker
 
-RUN chmod +x /bin/docker
+RUN chmod +x /bin/docker-*
 RUN cd /go/src/goproxy; go install
+RUN cd /go/src/gosetup; go install
 
 CMD ["/bin/bash","/srv/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ COPY ./world /srv/world
 COPY ./docs/img/logo64x64.png /srv/logo.png
 COPY ./start.sh /srv/start.sh
 COPY ./go /go
-COPY ./docker_linux_x64 /bin
+
+# download latest docker client
+ADD https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 /bin/docker-1.9.1
 
 RUN chmod +x /bin/docker-*
 RUN cd /go/src/goproxy; go install

--- a/go/src/goproxy/main.go
+++ b/go/src/goproxy/main.go
@@ -27,7 +27,7 @@ import (
 // instance of DockerClient allowing for making calls to the docker daemon
 // remote API
 var DOCKER_CLIENT *dockerclient.DockerClient
-var DOCKER_VERSION_TO_USE string
+var DOCKER_DAEMON_VERSION string
 
 type CPUStats struct {
 	TotalUsage  uint64
@@ -70,7 +70,7 @@ func main() {
 	if err != nil {
 		logrus.Fatal(err.Error())
 	}
-	DOCKER_VERSION_TO_USE = version.Version
+	DOCKER_DAEMON_VERSION = version.Version
 
 	// start monitoring docker events
 	DOCKER_CLIENT.StartMonitorEvents(eventCallback, nil)
@@ -221,7 +221,7 @@ func execCmd(w http.ResponseWriter, r *http.Request) {
 		if len(arr) > 0 {
 
 			if arr[0] == "docker" {
-				arr[0] = "docker-" + DOCKER_VERSION_TO_USE
+				arr[0] = "docker-" + DOCKER_DAEMON_VERSION
 			}
 
 			cmd := exec.Command(arr[0], arr[1:]...)

--- a/go/src/goproxy/main.go
+++ b/go/src/goproxy/main.go
@@ -27,6 +27,7 @@ import (
 // instance of DockerClient allowing for making calls to the docker daemon
 // remote API
 var DOCKER_CLIENT *dockerclient.DockerClient
+var DOCKER_VERSION_TO_USE string
 
 type CPUStats struct {
 	TotalUsage  uint64
@@ -63,6 +64,13 @@ func main() {
 	if err != nil {
 		logrus.Fatal(err.Error())
 	}
+
+	// get the version of the docker remote API
+	version, err := DOCKER_CLIENT.Version()
+	if err != nil {
+		logrus.Fatal(err.Error())
+	}
+	DOCKER_VERSION_TO_USE = version.Version
 
 	// start monitoring docker events
 	DOCKER_CLIENT.StartMonitorEvents(eventCallback, nil)
@@ -211,6 +219,11 @@ func execCmd(w http.ResponseWriter, r *http.Request) {
 		cmd, _ = url.QueryUnescape(cmd)
 		arr := strings.Split(cmd, " ")
 		if len(arr) > 0 {
+
+			if arr[0] == "docker" {
+				arr[0] = "docker-" + DOCKER_VERSION_TO_USE
+			}
+
 			cmd := exec.Command(arr[0], arr[1:]...)
 			// Stdout buffer
 			// cmdOutput := &bytes.Buffer{}

--- a/go/src/gosetup/main.go
+++ b/go/src/gosetup/main.go
@@ -12,21 +12,21 @@ import (
 
 // instance of DockerClient allowing for making calls to the docker daemon
 // remote API
-var DOCKER_CLIENT *dockerclient.DockerClient
+var dockerClient *dockerclient.DockerClient
 
 
 func main() {
 
 	// init docker client object
 	var err error
-	DOCKER_CLIENT, err = dockerclient.NewDockerClient("unix:///var/run/docker.sock", nil)
+	dockerClient, err = dockerclient.NewDockerClient("unix:///var/run/docker.sock", nil)
 	if err != nil {
 		logrus.Fatal(err.Error())
 	}
 
 	// get the version of the docker daemon so we can be sure the corresponding
 	// docker client is installed and install it if necessary
-	version, err := DOCKER_CLIENT.Version()
+	version, err := dockerClient.Version()
 	if err != nil {
 		logrus.Fatal(err.Error())
 	}

--- a/go/src/gosetup/main.go
+++ b/go/src/gosetup/main.go
@@ -24,22 +24,23 @@ func main() {
 		logrus.Fatal(err.Error())
 	}
 
-	// get the version of the docker remote API
+	// get the version of the docker daemon so we can be sure the corresponding
+	// docker client is installed and install it if necessary
 	version, err := DOCKER_CLIENT.Version()
 	if err != nil {
 		logrus.Fatal(err.Error())
 	}
-	dockerVersionNeeded := version.Version
+	dockerDaemonVersion := version.Version
 
 	// name of docker binary that is needed 
-	dockerBinaryName := "docker-" + dockerVersionNeeded
+	dockerBinaryName := "docker-" + dockerDaemonVersion
 	logrus.Println("looking for docker binary named:", dockerBinaryName)
 
 	filename := path.Join("/bin", dockerBinaryName)
 	
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
 		
-		logrus.Println("docker binary (version " + dockerVersionNeeded + ") not found.")
+		logrus.Println("docker binary (version " + dockerDaemonVersion + ") not found.")
 		logrus.Println("downloading", dockerBinaryName, "...")
 
 		out, err := os.Create(filename)
@@ -47,7 +48,7 @@ func main() {
 			logrus.Fatal(err.Error())
 		}
 		defer out.Close()
-		resp, err := http.Get("https://get.docker.com/builds/Linux/x86_64/docker-" + dockerVersionNeeded)
+		resp, err := http.Get("https://get.docker.com/builds/Linux/x86_64/docker-" + dockerDaemonVersion)
 		if err != nil {
 			logrus.Fatal(err.Error())
 		}

--- a/go/src/gosetup/main.go
+++ b/go/src/gosetup/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path"
+	"net/http"
+	"io"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/samalba/dockerclient"
+)
+
+// instance of DockerClient allowing for making calls to the docker daemon
+// remote API
+var DOCKER_CLIENT *dockerclient.DockerClient
+
+
+func main() {
+
+	// init docker client object
+	var err error
+	DOCKER_CLIENT, err = dockerclient.NewDockerClient("unix:///var/run/docker.sock", nil)
+	if err != nil {
+		logrus.Fatal(err.Error())
+	}
+
+	// get the version of the docker remote API
+	version, err := DOCKER_CLIENT.Version()
+	if err != nil {
+		logrus.Fatal(err.Error())
+	}
+	dockerVersionNeeded := version.Version
+
+	// name of docker binary that is needed 
+	dockerBinaryName := "docker-" + dockerVersionNeeded
+	logrus.Println("looking for docker binary named:", dockerBinaryName)
+
+	filename := path.Join("/bin", dockerBinaryName)
+	
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		
+		logrus.Println("docker binary (version " + dockerVersionNeeded + ") not found.")
+		logrus.Println("downloading", dockerBinaryName, "...")
+
+		out, err := os.Create(filename)
+		if err != nil {
+			logrus.Fatal(err.Error())
+		}
+		defer out.Close()
+		resp, err := http.Get("https://get.docker.com/builds/Linux/x86_64/docker-" + dockerVersionNeeded)
+		if err != nil {
+			logrus.Fatal(err.Error())
+		}
+		defer resp.Body.Close()
+		
+		_, err = io.Copy(out, resp.Body)
+		if err != nil {
+			logrus.Fatal(err.Error())
+		}
+
+		err = os.Chmod(filename, 0700)
+		if err != nil {
+			logrus.Fatal(err.Error())
+		}
+    }
+}

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,6 @@
+# Download the version of the docker client that matches the docker daemon present
+gosetup
+
 # Start goproxy
 goproxy &> /srv/world/goproxy_out &
 


### PR DESCRIPTION
- image build context now contains the docker clients for the last two versions of docker: 1.9.0 and 1.9.1
- if the docker daemon does not match one of those versions, a small program (gosetup) will download the compatible docker client and install it when the container is started

fixes #21 