### PR TITLE
Copy last Docker binary (again)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,19 @@
 FROM golang:1.5.1
 
-COPY ./cuberite_server /srv/cuberite_server
-COPY ./world /srv/world
-COPY ./docs/img/logo64x64.png /srv/logo.png
-COPY ./start.sh /srv/start.sh
-COPY ./go /go
-
-# download latest docker client
-ADD https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 /bin/docker-1.9.1
-
+# Copy latest docker client(s)
+COPY ./docker/docker-1.9.1 /bin/docker-1.9.1
 RUN chmod +x /bin/docker-*
+
+# Copy Go code and install applications
+COPY ./go /go
 RUN cd /go/src/goproxy; go install
 RUN cd /go/src/gosetup; go install
 
+# Copy Cuberite server (Minecraft C++ server)
+# with special empty world for Dockercraft
+COPY ./cuberite_server /srv/cuberite_server
+COPY ./world /srv/world
+COPY ./docs/img/logo64x64.png /srv/logo.png
+
+COPY ./start.sh /srv/start.sh
 CMD ["/bin/bash","/srv/start.sh"]


### PR DESCRIPTION
Finally, I don't think it's a good thing to download the last Docker binary from get.docker.com.
It can't be cached, so it takes a lot of time to rebuild. Also we're not checking downloaded file's hash, so the binary itself could be corrupted.

I would prefer to copy the binary, like we did before.
Also, I reordered some operations in the Dockerfile, to rebuild faster when we just update Lua scripts for instance. 

Signed-off-by: Adrien Duermael <adrien@docker.com>