### PR TITLE
update MAINTAINERS file to the new toml format

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,40 @@
-Adrien Duermael <adrien@docker.com> (@aduermael)
-Gaetan de Villele <gaetan@docker.com> (@gdevillele)
-Dave Tucker <dave.tucker@docker.com> (@dave-tucker)
+# Dockercraft maintainers file
+#
+# This file describes who runs the docker/dockercraft project and how.
+# This is a living document - if you see something out of date or missing, speak up!
+#
+# It is structured to be consumable by both humans and programs.
+# To extract its contents programmatically, use any TOML-compliant parser.
+#
+# This file is compiled into the MAINTAINERS file in docker/opensource.
+#
+[Org]
+	[Org."Core maintainers"]
+		people = [
+			"aduermael",
+			"davetucker",
+			"gdevillele",
+		]
+
+[people]
+
+# A reference list of all people associated with the project.
+# All other sections should refer to people by their canonical key
+# in the people section.
+
+	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
+
+	[people.aduermael]
+	Name = "Adrien Duermael"
+	Email = "adrien@docker.com"
+	GitHub = "aduermael"
+
+	[people.davetucker]
+	Name = "Dave Tucker"
+	Email = "dave.tucker@docker.com"
+	GitHub = "dave-tucker"
+
+	[people.gdevillele]
+	Name = "Gaetan de Villele"
+	Email = "gaetan@docker.com"
+	GitHub = "gdevillele"


### PR DESCRIPTION
this updates the MAINTAINERS file to the new toml format,
so that it can be parsed and collected in the docker/opensource
repository.

see docker/opensource#35 and docker/docker#18321

Then you can be added here https://github.com/docker/opensource/blob/master/MAINTAINERS#L225