### PR TITLE
Fix Issue 44 - Get the docker client from the tgz file

### DIFF
--- a/go/src/gosetup/main.go
+++ b/go/src/gosetup/main.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"strings"
 	"strconv"
+	"strings"
 )
 
 const (
@@ -57,15 +57,15 @@ func main() {
 		}
 		defer out.Close()
 
-		versionComp, err := CompareVersions(dockerDaemonVersion, "1.11.0");
+		versionComp, err := CompareVersions(dockerDaemonVersion, "1.11.0")
 		if err != nil {
 			logrus.Fatal(err.Error())
 		}
 
 		if versionComp >= 0 {
-			getClient(out,"https://get.docker.com/builds/Linux/x86_64/docker-" + dockerDaemonVersion + ".tgz", extractClient)
+			getClient(out, "https://get.docker.com/builds/Linux/x86_64/docker-"+dockerDaemonVersion+".tgz", extractClient)
 		} else {
-			getClient(out,"https://get.docker.com/builds/Linux/x86_64/docker-" + dockerDaemonVersion, copyClient)
+			getClient(out, "https://get.docker.com/builds/Linux/x86_64/docker-"+dockerDaemonVersion, copyClient)
 		}
 
 		err = os.Chmod(filename, 0700)
@@ -104,7 +104,6 @@ func CompareVersions(v1 string, v2 string) (comp int, err error) {
 	}
 	return 0, nil
 }
-
 
 func copyClient(out *os.File, resp *http.Response) {
 	_, err := io.Copy(out, resp.Body)

--- a/go/src/gosetup/main.go
+++ b/go/src/gosetup/main.go
@@ -1,20 +1,19 @@
 package main
 
 import (
-	"os"
-	"path"
-	"net/http"
-	"io"
 	"archive/tar"
 	"compress/gzip"
 	"github.com/Sirupsen/logrus"
 	"github.com/samalba/dockerclient"
+	"io"
+	"net/http"
+	"os"
+	"path"
 )
 
 // instance of DockerClient allowing for making calls to the docker daemon
 // remote API
 var dockerClient *dockerclient.DockerClient
-
 
 func main() {
 
@@ -33,14 +32,14 @@ func main() {
 	}
 	dockerDaemonVersion := version.Version
 
-	// name of docker binary that is needed 
+	// name of docker binary that is needed
 	dockerBinaryName := "docker-" + dockerDaemonVersion
 	logrus.Println("looking for docker binary named:", dockerBinaryName)
 
-        filename := path.Join("/bin", dockerBinaryName)
-	
+	filename := path.Join("/bin", dockerBinaryName)
+
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
-		
+
 		logrus.Println("docker binary (version " + dockerDaemonVersion + ") not found.")
 		logrus.Println("downloading", dockerBinaryName, "...")
 
@@ -56,34 +55,34 @@ func main() {
 		defer resp.Body.Close()
 
 		gr, err := gzip.NewReader(resp.Body)
-                defer gr.Close()
-                if err != nil {
-                       logrus.Fatal(err.Error())
-                }
+		defer gr.Close()
+		if err != nil {
+			logrus.Fatal(err.Error())
+		}
 
-                tr := tar.NewReader(gr)
-                for {
-                        hdr, err := tr.Next()
-                        if err == io.EOF {
-                               break
-                        }
-                        if err != nil {
-                               logrus.Fatal(err.Error())
-                        }
+		tr := tar.NewReader(gr)
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				logrus.Fatal(err.Error())
+			}
 
-                        if hdr.Typeflag == tar.TypeReg && hdr.Name == "docker/docker" {
-                                _, err = io.Copy(out, tr)
-                                if err != nil {
-                                        logrus.Fatal(err.Error())
-		                }
-                                break
-                        }
-                        logrus.Println("not yet")
-                }
+			if hdr.Typeflag == tar.TypeReg && hdr.Name == "docker/docker" {
+				_, err = io.Copy(out, tr)
+				if err != nil {
+					logrus.Fatal(err.Error())
+				}
+				break
+			}
+			logrus.Println("not yet")
+		}
 
 		err = os.Chmod(filename, 0700)
 		if err != nil {
 			logrus.Fatal(err.Error())
 		}
-    }
+	}
 }


### PR DESCRIPTION
This fixes issue #44.  On my system I was not getting a valid docker executable.  I couldn't find a way to directly download the docker client, even using the url constructed in the code.  I could find a `tgz` file, though.  This change pulls the `tgz` file for your version and copies out the docker client.

Tested with Docker 1.11.2