### PR TITLE
Documentation update

### DIFF
--- a/vendor/github.com/docker/docker/docs/security/trust/trust_sandbox.md
+++ b/vendor/github.com/docker/docker/docs/security/trust/trust_sandbox.md
@@ -83,7 +83,7 @@ the `trustsandbox` container, the Notary server, and the Registry server.
         version: "2"
         services:
           notaryserver:
-            image: dockersecurity/notary_autobuilds:server
+            image: dockersecurity/notary_autobuilds:server-latest
             volumes:
               - notarycerts:/go/src/github.com/docker/notary/fixtures
             networks:


### PR DESCRIPTION
Updated documentation on using the trust sandbox example to fix an issue where the notary server tag was not found.

Signed-off-by: Matthew Lapworth <matthewl@bit-shift.net>