### PR TITLE
Update maintainers list

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -12,7 +12,7 @@
 	[Org."Core maintainers"]
 		people = [
 			"aduermael",
-			"davetucker",
+			"dave-tucker",
 			"gdevillele",
 		]
 
@@ -29,9 +29,9 @@
 	Email = "adrien@docker.com"
 	GitHub = "aduermael"
 
-	[people.davetucker]
+	[people.dave-tucker]
 	Name = "Dave Tucker"
-	Email = "dave.tucker@docker.com"
+	Email = "dt@docker.com"
 	GitHub = "dave-tucker"
 
 	[people.gdevillele]


### PR DESCRIPTION
Dave's name and e-mail was written different
in other repo's, resulting him to be listed
_twice_ in the global maintainers list :)

ping @dave-tucker @aduermael PTAL :smile: