### PR TITLE
update Dockerfile to use multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,31 @@
-FROM golang:1.8
+FROM alpine:3.6 AS wget
+RUN apk add --no-cache ca-certificates wget tar
 
-ENV DOCKER_VERSION 17.04.0-ce
-ENV CUBERITE_BUILD 630
+FROM wget AS docker
+ARG DOCKER_VERSION=17.04.0-ce
+RUN wget -qO- https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz | \
+  tar -xvz --strip-components=1 -C /bin
 
-# Copy latest docker client(s)
-RUN curl -sSL -o docker.tgz https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz &&\
-	tar -xvf docker.tgz --strip-components=1 -C /bin && rm docker.tgz &&\
-	chmod +x /bin/docker-* &&\
-	ln -s /bin/docker /bin/docker-${DOCKER_VERSION}
-
-# Download Cuberite server (Minecraft C++ server)
+FROM wget AS cuberite
+ARG CUBERITE_BUILD=630
 WORKDIR /srv
-RUN curl "https://builds.cuberite.org/job/Cuberite Linux x64 Master/${CUBERITE_BUILD}/artifact/Cuberite.tar.gz" | tar -xzf -
+RUN wget -qO- "https://builds.cuberite.org/job/Cuberite Linux x64 Master/${CUBERITE_BUILD}/artifact/Cuberite.tar.gz" |\
+  tar -xzf -
+
+FROM golang:1.8 AS dockercraft
+WORKDIR /go/src/github.com/docker/dockercraft
+COPY . .
+RUN go install
+
+FROM debian:jessie
+COPY --from=dockercraft /go/bin/dockercraft /bin
+COPY --from=docker /bin/docker /bin
+COPY --from=cuberite /srv /srv
 
 # Copy Dockercraft config and plugin
 COPY ./config /srv/Server
 COPY ./docs/img/logo64x64.png /srv/Server/favicon.png
 COPY ./Docker /srv/Server/Plugins/Docker
 
-# Copy Go code and install
-WORKDIR /go/src/github.com/docker/dockercraft
-COPY . .
-RUN go install
-
 EXPOSE 25565
-
 ENTRYPOINT ["/srv/Server/start.sh"]
-


### PR DESCRIPTION
Refactor Dockerfile to use multi-stage build
Also, allow specifying

`Docker Version` via `docker build --build-arg DOCKER_VERSION=17.03.1-ce .`

and `Cuberite Build` via `docker build --build-arg CUBERITE_BUILD=540 .`

The final image size is 7 times smaller.