### PR TITLE
Fixed a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ This is just the beginning for Dockercraft! We should be able to support a lot m
 - ...
 
 If you're interested about Dockercraft's design, discussions happen in [that issue](https://github.com/docker/dockercraft/issues/19).
-Also, we're using [Magicavoxel](https://voxel.codeplex.com) to do these nice prototypes:
+Also, we're using [Magicavoxel](https://ephtracy.github.io/) to do these nice prototypes:
 
 ![Dockercraft](https://github.com/docker/dockercraft/raw/master/docs/img/voxelproto.jpg?raw=true)
 


### PR DESCRIPTION
Hello there! I was checking out this repository and found that you had an outdated link for MagicaVoxel in the README. This pull request fixes that. Thanks!